### PR TITLE
Add config options to send log to syslog or only syslog

### DIFF
--- a/mozdef_client_config.conf.sample
+++ b/mozdef_client_config.conf.sample
@@ -3,6 +3,10 @@
 #
 # An optional 'stop sending events' flag.
 send_events = True
+# Send event additionally to syslog
+send_to_syslog = False
+# Only send to syslog (never send to mozdef url)
+syslog_only = False
 
 # The URL of your host is the main item needed.
 # Mandatory if send_events is (default) True

--- a/mozdef_client_config.py
+++ b/mozdef_client_config.py
@@ -80,6 +80,18 @@ class ConfigedMozDefEvent(ConfigFetchMixin, MozDefEvent):  # pylint: disable=too
         # when it's off.
         self.set_verify(True)
 
+        # Turn on syslog logging via config
+        try:
+            self._send_to_syslog = _configfile.getboolean('mozdef', 'send_to_syslog')
+        except (configparser.NoOptionError, configparser.NoSectionError):
+            self._send_to_syslog = False
+
+        # Allow to only send to syslog via config
+        try:
+            self._syslog_only = _configfile.getboolean('mozdef', 'syslog_only')
+        except (configparser.NoOptionError, configparser.NoSectionError):
+            self._syslog_only = False
+
     def send(self, *args, **kwargs):
         """ A cutoff to avoid sending events """
         if self._send_events:


### PR DESCRIPTION
These instance variables eventually get used via MozDefMessage (which is the parent of MozDefEvent) https://github.com/mozilla/mozdef_client/blob/master/mozdef_client/message.py#L118-L121 